### PR TITLE
Add simple alarm and basic daemon command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /nano
 /DATA
 /*/TESTDATA
+TESTDATA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN go get \
   github.com/frankh/crypto/ed25519 \
   github.com/golang/crypto/blake2b \
   github.com/pkg/errors \
-  github.com/dgraph-io/badger
+  github.com/dgraph-io/badger \
+  github.com/spf13/cobra
 
 COPY . ./
 
@@ -16,4 +17,4 @@ FROM debian:8-slim
 
 COPY --from=gobuild /go/src/github.com/frankh/nano/nano /nano
 
-ENTRYPOINT ["/nano"]
+ENTRYPOINT ["/nano", "daemon"]

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"net"
+	"time"
+
+	"github.com/frankh/nano/node"
+	"github.com/frankh/nano/store"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	InitialPeer string
+	TestNet     bool
+)
+
+func init() {
+	rootCmd.AddCommand(daemonCmd)
+	daemonCmd.Flags().StringVarP(&InitialPeer, "peer", "p", "::ffff:192.168.0.70", "Initial peer to make contact with")
+	daemonCmd.Flags().BoolVarP(&TestNet, "testnet", "t", false, "Use test network configuration")
+}
+
+var daemonCmd = &cobra.Command{
+	Use:   "daemon",
+	Short: "Starts the node's daemon",
+	Long:  `Starts a full Nano node as a long-running process.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		node.DefaultPeer = node.Peer{
+			net.ParseIP(InitialPeer),
+			7075,
+		}
+
+		if TestNet {
+			store.Init(store.TestConfig)
+		} else {
+			store.Init(store.LiveConfig)
+		}
+
+		keepAliveSender := node.NewAlarm(node.AlarmFn(node.SendKeepAlives), []interface{}{node.PeerList}, 20*time.Second)
+		node.ListenForUdp()
+
+		keepAliveSender.Stop()
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "nanode",
+	Short: "Nanode is a Go-based Nano node",
+	Long:  `Nanode is a Go-based Nano node`,
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/nano.go
+++ b/nano.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	"time"
-
-	"github.com/frankh/nano/node"
-	"github.com/frankh/nano/store"
+	"github.com/frankh/nano/cmd"
 )
 
 func main() {
-	store.Init(store.LiveConfig)
-
-	keepAliveSender := node.NewAlarm(node.AlarmFn(node.SendKeepAlives), []interface{}{node.PeerList}, 20*time.Second)
-	node.ListenForUdp()
-
-	keepAliveSender.Stop()
+	cmd.Execute()
 }

--- a/nano.go
+++ b/nano.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/frankh/nano/node"
 	"github.com/frankh/nano/store"
 )
@@ -8,6 +10,8 @@ import (
 func main() {
 	store.Init(store.LiveConfig)
 
-	node.SendKeepAlive(node.PeerList[0])
+	keepAliveSender := node.NewAlarm(node.AlarmFn(node.SendKeepAlives), []interface{}{node.PeerList}, 20*time.Second)
 	node.ListenForUdp()
+
+	keepAliveSender.Stop()
 }

--- a/node/alarm.go
+++ b/node/alarm.go
@@ -1,0 +1,41 @@
+package node
+
+import (
+	"time"
+)
+
+type AlarmFn func([]interface{})
+
+type Alarm struct {
+	fn       AlarmFn
+	fnParams []interface{}
+	duration time.Duration
+	done     chan bool
+}
+
+func NewAlarm(fn AlarmFn, fnParams []interface{}, d time.Duration) *Alarm {
+	a := &Alarm{fn, fnParams, d, make(chan bool)}
+
+	go a.Run()
+
+	return a
+}
+
+func (a *Alarm) Run() {
+	ticker := time.NewTicker(a.duration)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-a.done:
+			return
+		case _ = <-ticker.C:
+			a.fn(a.fnParams)
+		}
+	}
+
+}
+
+func (a *Alarm) Stop() {
+	a.done <- true
+}

--- a/node/alarm.go
+++ b/node/alarm.go
@@ -22,6 +22,8 @@ func NewAlarm(fn AlarmFn, fnParams []interface{}, d time.Duration) *Alarm {
 }
 
 func (a *Alarm) Run() {
+	a.fn(a.fnParams)
+
 	ticker := time.NewTicker(a.duration)
 	defer ticker.Stop()
 

--- a/node/node_net.go
+++ b/node/node_net.go
@@ -11,10 +11,26 @@ const packetSize = 512
 const numberOfPeersToShare = 8
 
 var DefaultPeer Peer
-var PeerList = []Peer{DefaultPeer}
-var PeerSet = map[string]bool{DefaultPeer.String(): true}
+var PeerList []Peer
+var PeerSet map[string]bool
+var LocalIP string
+
+// Get preferred outbound ip of this machine
+func GetOutboundIP() net.IP {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP
+}
 
 func ListenForUdp() {
+	LocalIP = GetOutboundIP().String()
+
 	log.Printf("Listening for udp packets on 7075")
 	ln, err := net.ListenPacket("udp", ":7075")
 	if err != nil {
@@ -24,19 +40,21 @@ func ListenForUdp() {
 	buf := make([]byte, packetSize)
 
 	for {
-		n, _, err := ln.ReadFrom(buf)
+		n, addr, err := ln.ReadFrom(buf)
 		if err != nil {
 			continue
 		}
+
+		source := addr.(*net.UDPAddr).IP.String()
 		if n > 0 {
-			handleMessage(bytes.NewBuffer(buf[:n]))
+			handleMessage(source, bytes.NewBuffer(buf[:n]))
 		}
 	}
 }
 
 func SendKeepAlive(peer Peer) error {
 	addr := peer.Addr()
-	randomPeers := make([]Peer, 0)
+	randomPeers := make([]Peer, 0, 2)
 
 	outConn, err := net.DialUDP("udp", nil, addr)
 	if err != nil {
@@ -60,7 +78,7 @@ func SendKeepAlive(peer Peer) error {
 }
 
 func SendKeepAlives(params []interface{}) {
-	peers := params[0].([]Peer)
+	peers := PeerList
 	for _, peer := range peers {
 		// TODO: Handle errors
 		SendKeepAlive(peer)

--- a/node/node_net.go
+++ b/node/node_net.go
@@ -10,11 +10,7 @@ import (
 const packetSize = 512
 const numberOfPeersToShare = 8
 
-var DefaultPeer = Peer{
-	net.ParseIP("::ffff:192.168.0.70"),
-	7075,
-}
-
+var DefaultPeer Peer
 var PeerList = []Peer{DefaultPeer}
 var PeerSet = map[string]bool{DefaultPeer.String(): true}
 

--- a/node/node_net.go
+++ b/node/node_net.go
@@ -62,3 +62,11 @@ func SendKeepAlive(peer Peer) error {
 	outConn.Write(buf.Bytes())
 	return nil
 }
+
+func SendKeepAlives(params []interface{}) {
+	peers := params[0].([]Peer)
+	for _, peer := range peers {
+		// TODO: Handle errors
+		SendKeepAlive(peer)
+	}
+}


### PR DESCRIPTION
- [x] Adds an `Alarm` type, which calls a function with some parameters, repetitively after the passing of a duration (Needs further optimizations and better error handling).
- [x] Adds cobra to help with writing the cli. Viper can be added for reading in config files, in a manner compatible with cobra.
- [x] Adds a simple `daemon` command which accepts `--testnet`, `--peer` and `--work-dir` flags, and starts store and node.
- [x] Adds source of udp message to the list of peers

I named the command `nanode`, but only because I had to name it something, and nano is perhaps not the best name (due to the nano editor being quite commonplace). Please change it to your preference.